### PR TITLE
submit job script for handling submission time values specified in a file

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,4 +5,5 @@ Utilities for InfoSphere Streams. Each directory is a distinct utility.
 
   * **ant**: Apache Ant tasks for Streams.
   * **lscpus**: displays CPU utilization for PEs in a Streams instance.
+  * **submitjob**: helper script for submitting a job with submission-time values specified in a file
 

--- a/submitjob/Main.spl
+++ b/submitjob/Main.spl
@@ -1,0 +1,15 @@
+
+composite Main {
+param
+    expression<int32> $year: (int32)getSubmissionTimeValue("year","0");
+    expression<rstring> $title: getSubmissionTimeValue("title","default");
+    expression<rstring> $author: getSubmissionTimeValue("author","default");
+graph
+
+    () as writer = Custom() {
+
+    logic onProcess: {
+         println("Book is "+$title+" from author "+$author+" from year "+(rstring)$year+" which is "+(rstring)(2015-$year)+" years ago");
+    }
+    }
+}

--- a/submitjob/README.md
+++ b/submitjob/README.md
@@ -13,5 +13,5 @@ This script lets you do that.  You can do
 
 You can use additional streamtool arguments by putting them after the file name, eg:
 `submitjob.pl output/Main.sab iliad.txt -i instancename -d domainname`
-See the testStandalone.sh and testDistributed.sh for example uses.
+See the `testStandalone.sh` and `testDistributed.sh` for example uses.
 

--- a/submitjob/README.md
+++ b/submitjob/README.md
@@ -1,0 +1,18 @@
+The submitjob.pl script submits the job given by the first argument with the parameters given by the second argument.  
+
+submitjob.pl output/Main.sab iliad.txt
+
+when iliad.txt is
+author=Homer
+title=The Iliad
+year=-1194
+
+is the same as 
+streamtool submitjob output/Main.sab iliad.txt -P author=Homer -P title='The Iliad' year=-1194
+
+You can use additional streamtool arguments by putting them after the file name, eg:
+
+submitjob.pl output/Main.sab iliad.txt -i instancename -d domainname
+
+See the testStandalone.sh and testDistributed.sh for example uses.
+

--- a/submitjob/README.md
+++ b/submitjob/README.md
@@ -1,18 +1,17 @@
-The submitjob.pl script submits the job given by the first argument with the parameters given by the second argument.  
+The submitjob.pl script submits the job given by the first argument with the parameters given by the second argument.   This can be useful when it's difficult to keep tract of all the submission time parameters in use for a job.  The `Main.spl` file contains a sample application with three submission time parameters, `title`, `author`, and `year`.  The application just prints out the value of its parameters.
 
-submitjob.pl output/Main.sab iliad.txt
-
-when iliad.txt is
+TFor example, you can do: 
+`streamtool submitjob output/Main.sab -P author=Homer -P title='The Iliad' year=-1194`
+but you might perfer to keep the submission time values in a file, `iliad.txt`:
+```
 author=Homer
 title=The Iliad
 year=-1194
-
-is the same as 
-streamtool submitjob output/Main.sab iliad.txt -P author=Homer -P title='The Iliad' year=-1194
+```
+This script lets you do that.  You can do
+`submitjob.pl output/Main.sab iliad.txt` and it will automatically parse the file and add the specified parameters to the command line.  
 
 You can use additional streamtool arguments by putting them after the file name, eg:
-
-submitjob.pl output/Main.sab iliad.txt -i instancename -d domainname
-
+`submitjob.pl output/Main.sab iliad.txt -i instancename -d domainname`
 See the testStandalone.sh and testDistributed.sh for example uses.
 

--- a/submitjob/iliad.txt
+++ b/submitjob/iliad.txt
@@ -1,0 +1,3 @@
+author=Homer
+year=-1194
+title=The Iliad

--- a/submitjob/submitjob.pl
+++ b/submitjob/submitjob.pl
@@ -1,0 +1,65 @@
+#!/usr/bin/perl
+
+use strict;
+
+sub buildCommandLine($$) {
+my ($configFile,$isStandalone) = @_;
+
+my $toReturn = "";
+open(INFILE,"<$configFile");
+
+while(<INFILE>) {
+  next if /^\#/;
+  next if /^\s*$/;
+  if (/\s*([^= ]+)\s*=\s*(.+)\s*$/) {
+     my $left = $1;
+     my $right = $2;
+     chomp($right);
+     if ($isStandalone) {
+       $toReturn .= " $left=\"$right\"";
+     }
+     else {
+    if ($toReturn ne "") {
+       $toReturn .= "\\\n\t";
+        }
+    $toReturn .= " -P $left=\"$right\"";
+     }
+  }
+  else {
+    print STDERR "Malformed line: $_";
+  }
+}
+return $toReturn;
+}
+
+sub main {
+
+if ($ARGV[0] eq "-h" || $ARGV[0] eq "--help" || $ARGV[0] eq "-?") {
+   print "Usage: submitjob.pl <sabfile> <parameterfile> [extra streamtool arguments]\n";
+   exit 0;
+}
+
+if (scalar(@ARGV) < 2) {
+    print "Usage: submitjob.pl <sabfile> <parameterfile> [extra sreamtool arguments]\n";
+}
+
+my $app = $ARGV[0];
+my $configFile = $ARGV[1];
+my @theRest = splice(@ARGV,2);
+my $standalone = 0;
+if ($ARGV[0] =~ /standalone/) {
+    $standalone = 1;
+}
+my $args = buildCommandLine($configFile,$standalone);
+
+my $remainingArgs = join(" ",@theRest);
+my $cmd = "streamtool submitjob $app $args $remainingArgs";
+if ($standalone) {
+    $cmd = "$app $args $remainingArgs";
+}
+#print $cmd;
+#print "\n";
+system($cmd);
+}
+main();
+

--- a/submitjob/testDistributed.sh
+++ b/submitjob/testDistributed.sh
@@ -1,0 +1,8 @@
+echo Using Streams domain $STREAMS_DOMAIN_ID
+echo Using Streams instance $STREAMS_DEFAULT_IID
+sc -M Main
+echo "Defaults:"
+./submitjob.pl output/Main.sab emptyParams.txt
+echo "Iliad:"
+./submitjob.pl output/Main.sab iliad.txt
+

--- a/submitjob/testStandalone.sh
+++ b/submitjob/testStandalone.sh
@@ -1,0 +1,6 @@
+sc -T -M Main
+echo "Defaults:"
+./submitjob.pl output/bin/standalone emptyParams.txt
+echo "Iliad:"
+./submitjob.pl output/bin/standalone iliad.txt
+


### PR DESCRIPTION
I recently needed a submitjob script for a client engagement, and I also noticed that there was [StreamsDev question](https://developer.ibm.com/answers/questions/189433/managing-many-submission-time-values/?smartspace=streamsdev) asking about this as well, so I figured that maybe I should contribute it on github.  

In addition to the submitjob.pl script, I'm also including:
* a readme.md file
* an application with a few submission-time values
* a couple different parameter files
* two test scripts, one for standalone, one for distributed, that show how to use the submitjob script.
