### PR TITLE
Avoid common REST tests appearing as skipped

### DIFF
--- a/python/test/common_tests.py
+++ b/python/test/common_tests.py
@@ -14,15 +14,7 @@ vcap_service_config_file_name = 'vcap_service_config.json'
 
 logger = logging.getLogger('streamsx.test.rest_test')
 
-class CommonTests(unittest.TestCase):
-    @classmethod
-    def setUpClass(cls):
-        """
-        Initialize the logger and get the SWS username, password, and REST URL.
-        :return: None
-        """
-        if cls is CommonTests:
-            raise unittest.SkipTest("Skipping base tests.")
+class CommonTests(object):
 
     def test_ensure_correct_rest_module(self):
         self.logger.debug("Beginning test: test_ensure_correct_rest_module.")

--- a/python/test/rest_bluemix_tests.py
+++ b/python/test/rest_bluemix_tests.py
@@ -4,8 +4,9 @@ from common_tests import CommonTests
 from streamsx import rest
 from streamsx.topology import context
 import json
+import unittest
 
-class TestRestFeaturesBluemix(CommonTests):
+class TestRestFeaturesBluemix(CommonTests, unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         """

--- a/python/test/rest_local_tests.py
+++ b/python/test/rest_local_tests.py
@@ -11,7 +11,7 @@ from common_tests import credentials_file_name
 
 from streamsx.topology import context
 
-class TestRestFeaturesLocal(CommonTests):
+class TestRestFeaturesLocal(CommonTests, unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         """


### PR DESCRIPTION
No need for the common tests to inherit for `unittest.TestCase`, instead have the actual test classes use multiple-inheritance.